### PR TITLE
Quote ingress paths to prevent rendering errors

### DIFF
--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -29,7 +29,7 @@ spec:
       http:
         paths:
           {{- range .paths }}
-          - path: {{ .path }}
+          - path: {{ .path | quote }}
             {{- with .pathType }}
             pathType: {{ . }}
             {{- end }}


### PR DESCRIPTION
## Summary
- quote path values in ingress template to handle special characters safely

## Testing
- `helm lint .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a04aa1561083269b6be1248d49f612